### PR TITLE
Fix xdg-open's arg

### DIFF
--- a/webserver/browser.go
+++ b/webserver/browser.go
@@ -37,7 +37,7 @@ import (
 	"strings"
 )
 
-var option = " --disable-extension  --app=http://%s"
+var option = " --disable-extension  --app=%s"
 
 func browsers(def string) []string {
 	if def != "" {

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -57,7 +57,7 @@ func New(bpath, firstPage string, strs ...interface{}) (*WebServer, error) {
 	}
 	var err error
 	addr := w.start()
-	w.Finished, err = tryBrowser(bpath, addr.String()+"/"+firstPage)
+	w.Finished, err = tryBrowser(bpath, "http://"+addr.String()+"/"+firstPage)
 	<-w.ch
 	return w, err
 }


### PR DESCRIPTION
xdg-open can't detect URI without "http://" schema


![nejeui01](https://cloud.githubusercontent.com/assets/1822861/19025552/34fc7dee-8955-11e6-9f17-0d90840b3854.png)
